### PR TITLE
pass jdbc url with ssl params

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name="sqlalchemy_jdbcapi",
-    version="1.2.1",
+    version="1.2.2",
     description=DESCRIPTION,
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/sqlalchemy_jdbcapi/__init__.py
+++ b/sqlalchemy_jdbcapi/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy.dialects import registry
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 registry.register(
     "jdbcapi.pgjdbc", "sqlalchemy_jdbcapi.pgjdbc", "PGJDBCDialect"


### PR DESCRIPTION
To support SSL the lib should support connection arguments and jdbc urls like `jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=10.5.220.121)(PORT=1522))(CONNECT_DATA=(SID=ORCLRGT)))`. The lib should also accept sqlalchemy create_engine() urls e.g. `oracle://scott:tiger@127.0.0.1:1521/sidname`.

The PR makes it possible in the following way:

- set connection properties on a system level via JVM System properties (note: there is no other way with Postgres)
- pass jdbc url via sqlalchemy create_engine() url as `oracle://(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=10.5.220.121)(PORT=1522))(CONNECT_DATA=(SID=ORCLRGT)))`

This also allows to not parse jdbc url for further constructing sqlalchemy create_engine(). Parsing jdbc urls is not trivial and should be passed on to drivers if possible.