### PR TITLE
Convert datetime to Java Timestamp in SQL statements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 79
-target-version = ['py37']
+target-version = ['py38']
 exclude = '''
     /(
         \.git
@@ -22,3 +22,4 @@ exclude = '''
       | setup.cfg:
       | project.toml
     )/
+'''

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name="sqlalchemy_jdbcapi",
-    version="1.3.0",
+    version="1.3.1",
     description=DESCRIPTION,
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/sqlalchemy_jdbcapi/oceanbasejdbc.py
+++ b/sqlalchemy_jdbcapi/oceanbasejdbc.py
@@ -1,5 +1,6 @@
 import re
 from abc import ABC
+from datetime import datetime
 from types import ModuleType
 
 import jaydebeapi
@@ -25,6 +26,19 @@ class OceanBaseCursor(jaydebeapi.Cursor):
                 string += chr(char)
             value = string
         return value
+
+    def _set_stmt_parms(self, prep_stmt, parameters):
+        """Override to handle datetime conversion."""
+        for i in range(len(parameters)):
+            v = parameters[i]
+            if isinstance(v, datetime):
+                # Convert Python datetime to Java Timestamp
+                import jpype
+                Timestamp = jpype.JClass("java.sql.Timestamp")
+                v = Timestamp.valueOf(v.strftime('%Y-%m-%d %H:%M:%S.%f'))
+            # print (i, parameters[i], type(parameters[i]))
+            prep_stmt.setObject(i + 1, v)
+
 
 
 class OceanBaseJDBCDialect(OracleDialect, ABC):


### PR DESCRIPTION
Implement a method to convert Python datetime objects to Java Timestamp format when setting statement parameters. Update project configuration for compatibility with Python 3.8 and increment version number.